### PR TITLE
refactor/setup env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,36 @@
 ### install dependencies
 
 ```bash
-pnpm i
+$ pnpm i
+```
+
+### create environment files
+
+```bash
+$ cp apps/frontend/.env.local.example apps/frontend/.env.local
+$ cp apps/backend/.dev.vars.example apps/backend/.dev.vars
 ```
 
 ### run dev server
 
 ```bash
-pnpm dev
+$ pnpm dev
 ```
 
 ### check format and lint
 
 ```bash
-pnpm check
+$ pnpm check
 ```
 
 ### format and lint fix
 
 ```bash
-pnpm fix
+$ pnpm fix
 ```
 
 ### typecheck
 
 ```bash
-pnpm typecheck
+$ pnpm typecheck
 ```

--- a/README.md
+++ b/README.md
@@ -5,36 +5,36 @@
 ### install dependencies
 
 ```bash
-$ pnpm i
+pnpm i
 ```
 
 ### create environment files
 
 ```bash
-$ cp apps/frontend/.env.local.example apps/frontend/.env.local
-$ cp apps/backend/.dev.vars.example apps/backend/.dev.vars
+cp apps/frontend/.env.local.example apps/frontend/.env.local
+cp apps/backend/.dev.vars.example apps/backend/.dev.vars
 ```
 
 ### run dev server
 
 ```bash
-$ pnpm dev
+pnpm dev
 ```
 
 ### check format and lint
 
 ```bash
-$ pnpm check
+pnpm check
 ```
 
 ### format and lint fix
 
 ```bash
-$ pnpm fix
+pnpm fix
 ```
 
 ### typecheck
 
 ```bash
-$ pnpm typecheck
+pnpm typecheck
 ```

--- a/apps/backend/.dev.vars.example
+++ b/apps/backend/.dev.vars.example
@@ -1,0 +1,1 @@
+FRONTEND_BASE_URL = http://localhost:5173

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,16 +1,23 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
+import { env } from 'hono/adapter'
 import { cors } from 'hono/cors'
 import { z } from 'zod'
 
 const app = new Hono()
 
-app.use(
-  '/*',
-  cors({
-    origin: 'http://localhost:5173', // frontendのURL
-  }),
-)
+app.use('/*', (c, next) => {
+  // biome-ignore lint/style/useNamingConvention: <explanation>
+  const { FRONTEND_BASE_URL } = env<{ FRONTEND_BASE_URL: string | undefined }>(c)
+  if (!FRONTEND_BASE_URL) {
+    throw new Error('FRONTEND_BASE_URL is not defined')
+  }
+  const arrowUrl = new URL(FRONTEND_BASE_URL).origin.toString()
+
+  return cors({
+    origin: arrowUrl,
+  })(c, next)
+})
 
 const allowedImageTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/heic', 'image/heif']
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 const app = new Hono()
 
 app.use('/*', (c, next) => {
-  // biome-ignore lint/style/useNamingConvention: <explanation>
+  // biome-ignore lint/style/useNamingConvention: The property name is in uppercase to match the naming convention for environment variables.
   const { FRONTEND_BASE_URL } = env<{ FRONTEND_BASE_URL: string | undefined }>(c)
   if (!FRONTEND_BASE_URL) {
     throw new Error('FRONTEND_BASE_URL is not defined')

--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_BASE_URL=http://localhost:8787

--- a/apps/frontend/src/routes/index.lazy.tsx
+++ b/apps/frontend/src/routes/index.lazy.tsx
@@ -7,7 +7,13 @@ export const Route = createLazyFileRoute('/')({
   component: () => <Home />,
 })
 
-const uploadClient = hc<ImageUploadRouteType>('http://localhost:8787') // backendのURL
+const BACKEND_BASE_URL: string | undefined = import.meta.env.VITE_BACKEND_BASE_URL
+if (!BACKEND_BASE_URL) {
+  throw new Error('BACKEND_BASE_URL is not defined')
+}
+const requestUrl = new URL(BACKEND_BASE_URL).origin.toString()
+
+const uploadClient = hc<ImageUploadRouteType>(requestUrl)
 const $imagePost = uploadClient.upload.image.$post
 
 const Home = () => {


### PR DESCRIPTION
## バックエンド
- cloudflareの環境変数ファイル`.dev.vars.example`を作成
- Honoのenv関数で環境変数ファイルからフロントエンドベースurlを取得
- URLコンストラクタで安全にcorsを許可する先を指定

## フロントエンド
- `.env.local.example`を作成
- viteの環境変数を利用してバックエンドベースurlを取得
- URLコンストラクタでAPIのリクエスト先を安全に指定

## ドキュメント
- 環境変数ファイルを作成するためのコマンドを記載
- `$`をコマンドの前につけた