### PR TITLE
バックエンドへのpath-aliasをやめる

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,8 +22,9 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
+    "backend": "workspace:*",
+    "biome-config": "workspace:*",
     "typescript": "^5.4.5",
-    "vite": "^5.2.12",
-    "biome-config": "workspace:*"
+    "vite": "^5.2.12"
   }
 }

--- a/apps/frontend/src/routes/index.lazy.tsx
+++ b/apps/frontend/src/routes/index.lazy.tsx
@@ -1,5 +1,5 @@
-import type { HonoRoutes } from '@backend-types/index'
 import { createLazyFileRoute } from '@tanstack/react-router'
+import type { HonoRoutes } from 'backend/src/index'
 import { hc } from 'hono/client'
 import { type ChangeEvent, useState } from 'react'
 

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,10 +6,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    "paths": {
-      "@backend-types/*": ["../backend/src/*"]
-    },
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
         version: 3.7.0(vite@5.3.0)
+      backend:
+        specifier: workspace:*
+        version: link:../backend
       biome-config:
         specifier: workspace:*
         version: link:../../packages/biome-config


### PR DESCRIPTION
## issue

resolve #12 

## 概要

frontendのtsconfigからbackendへのpath-aliasを削除。
devDependenciesにbackendのworkspaceを追加。