### PR TITLE
Feat/get recipes from web #6

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,6 @@
     "@hono/zod-validator": "^0.2.2",
     "@langchain/core": "^0.2.6",
     "@langchain/openai": "^0.1.3",
-    "axios": "^1.7.2",
     "cheerio": "1.0.0-rc.12",
     "hono": "^4.4.5",
     "langchain": "^0.2.5",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "scripts": {
-    "dev": "wrangler dev src/index.ts",
+    "dev": "wrangler dev src/index.ts --port 8787",
     "deploy": "wrangler deploy --minify src/index.ts",
     "check": "biome check ./src/",
     "fix": "biome check --write ./src/",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,8 @@
     "@hono/zod-validator": "^0.2.2",
     "@langchain/core": "^0.2.6",
     "@langchain/openai": "^0.1.3",
+    "axios": "^1.7.2",
+    "cheerio": "1.0.0-rc.12",
     "hono": "^4.4.5",
     "langchain": "^0.2.5",
     "zod": "^3.23.8"
@@ -21,5 +23,6 @@
     "biome-config": "workspace:*",
     "typescript": "^5.4.5",
     "wrangler": "^3.57.2"
-  }
+  },
+  "type": "module"
 }

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import cheerio from 'cheerio'
 import type { ingredients } from './schemas/ingredientsSchema'
 import { type Recipes, recipesSchema } from './schemas/recipesSchema'
@@ -6,7 +5,8 @@ import { createSearchRecipesUrl } from './utils/createSearchUrl'
 
 const fetchRecipes = async (url: string): Promise<Recipes> => {
   try {
-    const { data } = await axios.get(url)
+    const res = await fetch(url)
+    const data = await res.text()
     const $ = cheerio.load(data)
     const recipes: Recipes = []
     $('.recipe-list .recipe-preview').each((index, element) => {

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -6,6 +6,7 @@ import { createSearchRecipesUrl } from './utils/createSearchUrl'
 const fetchRecipes = async (url: string): Promise<Recipes> => {
   try {
     const res = await fetch(url)
+    if (!res.ok) throw new Error(`Failed to fetch the recipes: ${res.statusText}`)
     const data = await res.text()
     const $ = cheerio.load(data)
     const recipes: Recipes = []

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -9,28 +9,29 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
     if (!res.ok) throw new Error(`Failed to fetch the recipes: ${res.statusText}`)
     const data = await res.text()
     const $ = load(data)
-    const recipes: Recipes = []
-    $('.recipe-list .recipe-preview').each((index, element) => {
-      try {
-        //要素を指定して抽出
-        const recipeImage = $(element).find('.recipe-image img').attr('src') || ''
-        const recipeTitle = $(element).find('.recipe-title').text().trim()
-        const ingredients = $(element)
-          .find('.ingredients')
-          .text()
-          .trim()
-          .split('、')
-          .map((ingredient) => ingredient.trim())
-          .filter((ingredient) => !ingredient.includes('\n...'))
-        const newRecipe = { recipeImage, recipeTitle, ingredients }
+    const recipes = $('.recipe-list .recipe-preview')
+      .map((index, element) => {
+        try {
+          //要素を指定して抽出
+          const recipeImage = $(element).find('.recipe-image img').attr('src') || ''
+          const recipeTitle = $(element).find('.recipe-title').text().trim()
+          const ingredients = $(element)
+            .find('.ingredients')
+            .text()
+            .trim()
+            .split('、')
+            .map((ingredient) => ingredient.trim())
+            .filter((ingredient) => !ingredient.includes('\n...'))
+          const newRecipe = { recipeImage, recipeTitle, ingredients }
 
-        // 配列挿入前にバリデーション
-        const validatedRecipe = recipesSchema.parse([newRecipe])[0]
-        recipes.push(validatedRecipe)
-      } catch (parseError) {
-        console.error(`Error parsing recipe at index ${index}:`, parseError)
-      }
-    })
+          // 配列挿入前にバリデーション
+          const validatedRecipe = recipesSchema.parse([newRecipe])[0]
+          return validatedRecipe
+        } catch (parseError) {
+          console.error(`Error parsing recipe at index ${index}:`, parseError)
+        }
+      })
+      .get()
     return recipes
   } catch (error) {
     console.error('Error fetching the recipes:', error)

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import cheerio from 'cheerio'
-import type { FoodList } from './schemas/foodListSchema'
+import type { ingredients } from './schemas/ingredientsSchema'
 import { type Recipes, recipesSchema } from './schemas/recipesSchema'
 import { createSearchRecipesUrl } from './utils/createSearchUrl'
 
@@ -11,6 +11,7 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
     const recipes: Recipes = []
     $('.recipe-list .recipe-preview').each((index, element) => {
       try {
+        //要素を指定して抽出
         const recipeImage = $(element).find('.recipe-image img').attr('src') || ''
         const recipeTitle = $(element).find('.recipe-title').text().trim()
         const ingredients = $(element)
@@ -22,7 +23,7 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
           .filter((ingredient) => !ingredient.includes('\n...'))
         const newRecipe = { recipeImage, recipeTitle, ingredients }
 
-        // バリデーション
+        // 配列挿入前にバリデーション
         const validatedRecipe = recipesSchema.parse([newRecipe])[0]
         recipes.push(validatedRecipe)
       } catch (parseError) {
@@ -36,9 +37,7 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
   }
 }
 
-export { fetchRecipes }
-
-const getRecipesByIngredients = async (ingredients: FoodList): Promise<Recipes> => {
+const getRecipesByIngredients = async (ingredients: ingredients): Promise<Recipes> => {
   const searchUrl = createSearchRecipesUrl(ingredients)
   return await fetchRecipes(searchUrl)
 }

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio'
+import { load } from 'cheerio'
 import type { ingredients } from './schemas/ingredientsSchema'
 import { type Recipes, recipesSchema } from './schemas/recipesSchema'
 import { createSearchRecipesUrl } from './utils/createSearchUrl'
@@ -8,7 +8,7 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
     const res = await fetch(url)
     if (!res.ok) throw new Error(`Failed to fetch the recipes: ${res.statusText}`)
     const data = await res.text()
-    const $ = cheerio.load(data)
+    const $ = load(data)
     const recipes: Recipes = []
     $('.recipe-list .recipe-preview').each((index, element) => {
       try {

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -1,0 +1,46 @@
+import axios from 'axios'
+import cheerio from 'cheerio'
+import type { FoodList } from './schemas/foodListSchema'
+import { type Recipes, recipesSchema } from './schemas/recipesSchema'
+import { createSearchRecipesUrl } from './utils/createSearchUrl'
+
+const fetchRecipes = async (url: string): Promise<Recipes> => {
+  try {
+    const { data } = await axios.get(url)
+    const $ = cheerio.load(data)
+    const recipes: Recipes = []
+    $('.recipe-list .recipe-preview').each((index, element) => {
+      try {
+        const recipeImage = $(element).find('.recipe-image img').attr('src') || ''
+        const recipeTitle = $(element).find('.recipe-title').text().trim()
+        const ingredients = $(element)
+          .find('.ingredients')
+          .text()
+          .trim()
+          .split('、')
+          .map((ingredient) => ingredient.trim())
+          .filter((ingredient) => !ingredient.includes('\n...'))
+        const newRecipe = { recipeImage, recipeTitle, ingredients }
+
+        // バリデーション
+        const validatedRecipe = recipesSchema.parse([newRecipe])[0]
+        recipes.push(validatedRecipe)
+      } catch (parseError) {
+        console.error(`Error parsing recipe at index ${index}:`, parseError)
+      }
+    })
+    return recipes
+  } catch (error) {
+    console.error('Error fetching the recipes:', error)
+    return []
+  }
+}
+
+export { fetchRecipes }
+
+const getRecipesByIngredients = async (ingredients: FoodList): Promise<Recipes> => {
+  const searchUrl = createSearchRecipesUrl(ingredients)
+  return await fetchRecipes(searchUrl)
+}
+
+export { getRecipesByIngredients }

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -4,38 +4,35 @@ import { type Recipes, recipeSchema } from './schemas/recipesSchema'
 import { createSearchRecipesUrl } from './utils/createSearchUrl'
 
 const fetchRecipes = async (url: string): Promise<Recipes> => {
-  try {
-    const res = await fetch(url)
-    if (!res.ok) throw new Error(`Failed to fetch the recipes: ${res.statusText}`)
-    const data = await res.text()
-    const $ = load(data)
-    const recipes = $('.recipe-list .recipe-preview')
-      .map((index, element) => {
-        const recipeImage = $(element).find('.recipe-image img').attr('src')
-        const recipeTitle = $(element).find('.recipe-title').text().trim()
-        const ingredients = $(element)
-          .find('.ingredients')
-          .text()
-          .trim()
-          .split('、')
-          .map((ingredient) => ingredient.trim())
-          .filter((ingredient) => !ingredient.includes('\n...'))
-        const newRecipe = { recipeImage, recipeTitle, ingredients }
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Failed to fetch the recipes: ${res.statusText}`)
+  const data = await res.text()
 
-        const validatedRecipe = recipeSchema.safeParse(newRecipe)
-        if (!validatedRecipe.success) {
-          console.error(`Invalid recipe at index ${index}:`, validatedRecipe.error)
-          return null
-        }
-        return validatedRecipe.data
-      })
-      .get()
-      .filter((recipe) => recipe !== null)
-    return recipes
-  } catch (error) {
-    console.error('Error fetching the recipes:', error)
-    return []
-  }
+  const $ = load(data)
+  const recipes = $('.recipe-list .recipe-preview')
+    .map((index, element) => {
+      const recipeImage = $(element).find('.recipe-image img').attr('src')
+      const recipeTitle = $(element).find('.recipe-title').text().trim()
+      const ingredients = $(element)
+        .find('.ingredients')
+        .text()
+        .trim()
+        .split('、')
+        .map((ingredient) => ingredient.trim())
+        .filter((ingredient) => !ingredient.includes('\n...'))
+      const newRecipe = { recipeImage, recipeTitle, ingredients }
+
+      const validatedRecipe = recipeSchema.safeParse(newRecipe)
+      if (!validatedRecipe.success) {
+        console.error(`Invalid recipe at index ${index}:`, validatedRecipe.error)
+        return null
+      }
+      return validatedRecipe.data
+    })
+    .get()
+    .filter((recipe) => recipe !== null)
+
+  return recipes
 }
 
 const getRecipesByIngredients = async (ingredients: ingredients): Promise<Recipes> => {

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -11,27 +11,26 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
     const $ = load(data)
     const recipes = $('.recipe-list .recipe-preview')
       .map((index, element) => {
-        try {
-          //要素を指定して抽出
-          const recipeImage = $(element).find('.recipe-image img').attr('src') || ''
-          const recipeTitle = $(element).find('.recipe-title').text().trim()
-          const ingredients = $(element)
-            .find('.ingredients')
-            .text()
-            .trim()
-            .split('、')
-            .map((ingredient) => ingredient.trim())
-            .filter((ingredient) => !ingredient.includes('\n...'))
-          const newRecipe = { recipeImage, recipeTitle, ingredients }
+        const recipeImage = $(element).find('.recipe-image img').attr('src')
+        const recipeTitle = $(element).find('.recipe-title').text().trim()
+        const ingredients = $(element)
+          .find('.ingredients')
+          .text()
+          .trim()
+          .split('、')
+          .map((ingredient) => ingredient.trim())
+          .filter((ingredient) => !ingredient.includes('\n...'))
+        const newRecipe = { recipeImage, recipeTitle, ingredients }
 
-          // 配列挿入前にバリデーション
-          const validatedRecipe = recipeSchema.parse(newRecipe)
-          return validatedRecipe
-        } catch (parseError) {
-          console.error(`Error parsing recipe at index ${index}:`, parseError)
+        const validatedRecipe = recipeSchema.safeParse(newRecipe)
+        if (!validatedRecipe.success) {
+          console.error(`Invalid recipe at index ${index}:`, validatedRecipe.error)
+          return null
         }
+        return validatedRecipe.data
       })
       .get()
+      .filter((recipe) => recipe !== null)
     return recipes
   } catch (error) {
     console.error('Error fetching the recipes:', error)

--- a/apps/backend/src/getRecipes.ts
+++ b/apps/backend/src/getRecipes.ts
@@ -1,6 +1,6 @@
 import { load } from 'cheerio'
 import type { ingredients } from './schemas/ingredientsSchema'
-import { type Recipes, recipesSchema } from './schemas/recipesSchema'
+import { type Recipes, recipeSchema } from './schemas/recipesSchema'
 import { createSearchRecipesUrl } from './utils/createSearchUrl'
 
 const fetchRecipes = async (url: string): Promise<Recipes> => {
@@ -25,7 +25,7 @@ const fetchRecipes = async (url: string): Promise<Recipes> => {
           const newRecipe = { recipeImage, recipeTitle, ingredients }
 
           // 配列挿入前にバリデーション
-          const validatedRecipe = recipesSchema.parse([newRecipe])[0]
+          const validatedRecipe = recipeSchema.parse(newRecipe)
           return validatedRecipe
         } catch (parseError) {
           console.error(`Error parsing recipe at index ${index}:`, parseError)

--- a/apps/backend/src/imageToFoods.ts
+++ b/apps/backend/src/imageToFoods.ts
@@ -1,7 +1,7 @@
 import { HumanMessage } from '@langchain/core/messages'
 import { ChatOpenAI } from '@langchain/openai'
-import { z } from 'zod'
 import type { BindingsType } from './factory'
+import { foodListSchema } from './schemas/foodListSchema'
 import { fileToBase64 } from './utils/fileToBase64'
 
 export const imageToFoods = async (file: File, envs: BindingsType) => {
@@ -24,11 +24,7 @@ export const imageToFoods = async (file: File, envs: BindingsType) => {
 
   const imageUrl = await fileToBase64(file)
 
-  const foodSchema = z.object({
-    ingredients: z.array(z.string()).describe('画像に含まれている食材のリスト'),
-  })
-
-  const structuredLlm = model.withStructuredOutput(foodSchema, { name: 'food_detection' })
+  const structuredLlm = model.withStructuredOutput(foodListSchema, { name: 'food_detection' })
 
   const message = new HumanMessage({
     content: [

--- a/apps/backend/src/imageToFoods.ts
+++ b/apps/backend/src/imageToFoods.ts
@@ -1,7 +1,7 @@
 import { HumanMessage } from '@langchain/core/messages'
 import { ChatOpenAI } from '@langchain/openai'
 import type { BindingsType } from './factory'
-import { foodListSchema } from './schemas/foodListSchema'
+import { ingredientsSchema } from './schemas/ingredientsSchema'
 import { fileToBase64 } from './utils/fileToBase64'
 
 export const imageToFoods = async (file: File, envs: BindingsType) => {
@@ -24,7 +24,9 @@ export const imageToFoods = async (file: File, envs: BindingsType) => {
 
   const imageUrl = await fileToBase64(file)
 
-  const structuredLlm = model.withStructuredOutput(foodListSchema, { name: 'food_detection' })
+  const structuredLlm = model.withStructuredOutput(ingredientsSchema, {
+    name: 'food_detection',
+  })
 
   const message = new HumanMessage({
     content: [
@@ -40,7 +42,7 @@ export const imageToFoods = async (file: File, envs: BindingsType) => {
   })
 
   const res = await structuredLlm.invoke([message])
-  const foodListData = res.ingredients
+  const foodsData = res.ingredients
 
-  return foodListData
+  return foodsData
 }

--- a/apps/backend/src/routers/recipes.ts
+++ b/apps/backend/src/routers/recipes.ts
@@ -6,13 +6,12 @@ import { ingredientsSchema } from '../schemas/ingredientsSchema'
 const recipesRouter = honoFactory
   .createApp()
   .get('/', zValidator('query', ingredientsSchema), async (c) => {
+    const { ingredients } = c.req.valid('query')
     try {
-      const { ingredients } = c.req.valid('query')
       const recipes = await getRecipesByIngredients({ ingredients })
       return c.json(recipes)
     } catch (error) {
-      console.error('Error in recipesRouter:', error)
-      return c.json({ error: 'An unexpected error occurred while fetching recipes' }, 500)
+      return c.json({ error }, 500)
     }
   })
 

--- a/apps/backend/src/routers/recipes.ts
+++ b/apps/backend/src/routers/recipes.ts
@@ -1,10 +1,9 @@
 import { zValidator } from '@hono/zod-validator'
 import { honoFactory } from '../factory'
-import { recipesReqSchema } from '../schemas/recipesSchema'
-
+import { recipeSchema } from '../schemas/recipesSchema'
 const recipesRouter = honoFactory
   .createApp()
-  .get('/', zValidator('query', recipesReqSchema), async (c) => {
+  .get('/', zValidator('query', recipeSchema), async (c) => {
     const { ingredients } = c.req.valid('query')
 
     return c.json({ message: `hello ${ingredients.join(', ')}` })

--- a/apps/backend/src/routers/recipes.ts
+++ b/apps/backend/src/routers/recipes.ts
@@ -1,12 +1,19 @@
 import { zValidator } from '@hono/zod-validator'
 import { honoFactory } from '../factory'
-import { recipeSchema } from '../schemas/recipesSchema'
+import { foodListSchema } from '../schemas/foodListSchema'
 const recipesRouter = honoFactory
   .createApp()
-  .get('/', zValidator('query', recipeSchema), async (c) => {
-    const { ingredients } = c.req.valid('query')
-
-    return c.json({ message: `hello ${ingredients.join(', ')}` })
+  .get('/', zValidator('query', foodListSchema), async (c) => {
+    console.log(c)
+    /*
+    try {
+      const { ingredients } = c.req.valid('query')
+      const recipes = await getRecipesByIngredients({ ingredients })
+      return c.json(recipes)
+    } catch (error) {
+      console.error('Error in recipesRouter:', error)
+      return c.json({ error: 'An unexpected error occurred while fetching recipes' }, 500)
+    } */
   })
 
 export { recipesRouter }

--- a/apps/backend/src/routers/recipes.ts
+++ b/apps/backend/src/routers/recipes.ts
@@ -1,9 +1,10 @@
 import { zValidator } from '@hono/zod-validator'
 import { honoFactory } from '../factory'
-import { foodListSchema } from '../schemas/foodListSchema'
+import { ingredientsSchema } from '../schemas/ingredientsSchema'
+
 const recipesRouter = honoFactory
   .createApp()
-  .get('/', zValidator('query', foodListSchema), async (c) => {
+  .get('/', zValidator('query', ingredientsSchema), async (c) => {
     console.log(c)
     /*
     try {

--- a/apps/backend/src/routers/recipes.ts
+++ b/apps/backend/src/routers/recipes.ts
@@ -1,12 +1,11 @@
 import { zValidator } from '@hono/zod-validator'
 import { honoFactory } from '../factory'
+import { getRecipesByIngredients } from '../getRecipes'
 import { ingredientsSchema } from '../schemas/ingredientsSchema'
 
 const recipesRouter = honoFactory
   .createApp()
   .get('/', zValidator('query', ingredientsSchema), async (c) => {
-    console.log(c)
-    /*
     try {
       const { ingredients } = c.req.valid('query')
       const recipes = await getRecipesByIngredients({ ingredients })
@@ -14,7 +13,7 @@ const recipesRouter = honoFactory
     } catch (error) {
       console.error('Error in recipesRouter:', error)
       return c.json({ error: 'An unexpected error occurred while fetching recipes' }, 500)
-    } */
+    }
   })
 
 export { recipesRouter }

--- a/apps/backend/src/schemas/foodListSchema.ts
+++ b/apps/backend/src/schemas/foodListSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 const foodListSchema = z.object({
-  ingredients: z.array(z.string()).describe('画像に含まれている食材のリスト'),
+  ingredients: z.array(z.string()).describe('食材のリスト'),
 })
 
 type FoodList = z.infer<typeof foodListSchema>

--- a/apps/backend/src/schemas/foodListSchema.ts
+++ b/apps/backend/src/schemas/foodListSchema.ts
@@ -1,8 +1,0 @@
-import { z } from 'zod'
-const foodListSchema = z.object({
-  ingredients: z.array(z.string()).describe('食材のリスト'),
-})
-
-type FoodList = z.infer<typeof foodListSchema>
-
-export { foodListSchema, type FoodList }

--- a/apps/backend/src/schemas/foodListSchema.ts
+++ b/apps/backend/src/schemas/foodListSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+const foodListSchema = z.object({
+  ingredients: z.array(z.string()).describe('画像に含まれている食材のリスト'),
+})
+
+type FoodList = z.infer<typeof foodListSchema>
+
+export { foodListSchema, type FoodList }

--- a/apps/backend/src/schemas/ingredientsSchema.ts
+++ b/apps/backend/src/schemas/ingredientsSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+const ingredientsSchema = z.object({
+  ingredients: z.array(z.string()).describe('食材のリスト'),
+})
+
+type ingredients = z.infer<typeof ingredientsSchema>
+
+export { ingredientsSchema, type ingredients }

--- a/apps/backend/src/schemas/recipesSchema.ts
+++ b/apps/backend/src/schemas/recipesSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
-export const recipeSchema = z.object({
-  recipeImage: z.string(),
-  recipeTitle: z.string(),
-  ingredients: z.array(z.string()),
+import { foodListSchema } from './foodListSchema'
+
+const recipeSchema = foodListSchema.extend({
+  recipeImage: z.string().url().describe('レシピの画像のURL'),
+  recipeTitle: z.string().describe('レシピのタイトル'),
 })
+const recipesSchema = z.array(recipeSchema)
+type Recipes = z.infer<typeof recipesSchema>
 
-export type Recipe = z.infer<typeof recipeSchema>
-export type Recipes = Recipe[]
-
-export const recipesSchema = z.array(recipeSchema)
+export { recipesSchema, type Recipes }

--- a/apps/backend/src/schemas/recipesSchema.ts
+++ b/apps/backend/src/schemas/recipesSchema.ts
@@ -9,4 +9,4 @@ const recipesSchema = z.array(recipeSchema)
 
 type Recipes = z.infer<typeof recipesSchema>
 
-export { recipesSchema, type Recipes }
+export { recipeSchema, recipesSchema, type Recipes }

--- a/apps/backend/src/schemas/recipesSchema.ts
+++ b/apps/backend/src/schemas/recipesSchema.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod'
-import { foodListSchema } from './foodListSchema'
+import { ingredientsSchema } from './ingredientsSchema'
 
-const recipeSchema = foodListSchema.extend({
+const recipeSchema = ingredientsSchema.extend({
   recipeImage: z.string().url().describe('レシピの画像のURL'),
   recipeTitle: z.string().describe('レシピのタイトル'),
 })
 const recipesSchema = z.array(recipeSchema)
+
 type Recipes = z.infer<typeof recipesSchema>
 
 export { recipesSchema, type Recipes }

--- a/apps/backend/src/schemas/recipesSchema.ts
+++ b/apps/backend/src/schemas/recipesSchema.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
+export const recipeSchema = z.object({
+  recipeImage: z.string(),
+  recipeTitle: z.string(),
+  ingredients: z.array(z.string()),
+})
 
-const recipesReqSchema = z
-  .object({
-    ingredients: z.array(z.string()),
-  })
-  .strict()
+export type Recipe = z.infer<typeof recipeSchema>
+export type Recipes = Recipe[]
 
-export { recipesReqSchema }
+export const recipesSchema = z.array(recipeSchema)

--- a/apps/backend/src/utils/createSearchUrl.ts
+++ b/apps/backend/src/utils/createSearchUrl.ts
@@ -1,0 +1,9 @@
+import type { FoodList } from '../schemas/foodListSchema'
+
+const createSearchRecipesUrl = (foodList: FoodList): string => {
+  const baseSearchUrl = 'https://cookpad.com/search/'
+  const searchParams = foodList.ingredients.map((food) => encodeURIComponent(food)).join('%20')
+  return `${baseSearchUrl}${searchParams}`
+}
+
+export { createSearchRecipesUrl }

--- a/apps/backend/src/utils/createSearchUrl.ts
+++ b/apps/backend/src/utils/createSearchUrl.ts
@@ -1,8 +1,10 @@
-import type { FoodList } from '../schemas/foodListSchema'
+import type { ingredients } from '../schemas/ingredientsSchema'
 
-const createSearchRecipesUrl = (foodList: FoodList): string => {
+const createSearchRecipesUrl = (ingredients: ingredients): string => {
   const baseSearchUrl = 'https://cookpad.com/search/'
-  const searchParams = foodList.ingredients.map((food) => encodeURIComponent(food)).join('%20')
+  const searchParams = ingredients.ingredients
+    .map((ingredients) => encodeURIComponent(ingredients))
+    .join('%20')
   return `${baseSearchUrl}${searchParams}`
 }
 

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -5,13 +5,9 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "lib": [
-      "ESNext"
-    ],
-    "types": [
-      "@cloudflare/workers-types"
-    ],
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
-  },
+  }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5173",
     "build": "tsc && vite build",
     "check": "biome check ./src/",
     "fix": "biome check --write ./src/",

--- a/apps/frontend/src/routes/index.lazy.tsx
+++ b/apps/frontend/src/routes/index.lazy.tsx
@@ -15,15 +15,36 @@ const requestUrl = new URL(BACKEND_BASE_URL).origin.toString()
 
 const honoRoutes = hc<HonoRoutes>(requestUrl)
 const $imagePost = honoRoutes.upload.$post
+const $getRecipes = honoRoutes.recipes.$get
 
 const Home = () => {
   const [file, setFile] = useState<File | null>(null)
   const [ingredients, setingredients] = useState<string[]>([])
+  const [recipes, setRecipes] = useState<
+    {
+      ingredients: string[]
+      recipeImage: string
+      recipeTitle: string
+    }[]
+  >([])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
       setFile(file)
+    }
+  }
+
+  const getRecipes = async () => {
+    const res = await $getRecipes({
+      query: { ingredients },
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setRecipes(data)
+    } else {
+      const data = await res.json()
+      console.error(data)
     }
   }
 
@@ -50,6 +71,23 @@ const Home = () => {
       <ul>
         {ingredients.map((food) => (
           <li key={food}>{food}</li>
+        ))}
+      </ul>
+
+      <button type="button" onClick={getRecipes}>
+        Get recipes
+      </button>
+      <ul>
+        {recipes.map((recipe) => (
+          <li key={recipe.recipeTitle}>
+            <img src={recipe.recipeImage} alt={recipe.recipeTitle} />
+            <h2>{recipe.recipeTitle}</h2>
+            <ul>
+              {recipe.ingredients.map((ingredient) => (
+                <li key={ingredient}>{ingredient}</li>
+              ))}
+            </ul>
+          </li>
         ))}
       </ul>
     </div>

--- a/apps/frontend/src/routes/index.lazy.tsx
+++ b/apps/frontend/src/routes/index.lazy.tsx
@@ -18,7 +18,7 @@ const $imagePost = honoRoutes.upload.$post
 
 const Home = () => {
   const [file, setFile] = useState<File | null>(null)
-  const [foods, setFoods] = useState<string[]>([])
+  const [ingredients, setingredients] = useState<string[]>([])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -34,7 +34,7 @@ const Home = () => {
     })
     if (res.ok) {
       const data = await res.json()
-      setFoods(data.foods)
+      setingredients(data.foods)
     } else {
       const data = await res.json()
       console.error(data.error)
@@ -48,7 +48,7 @@ const Home = () => {
         Upload image
       </button>
       <ul>
-        {foods.map((food) => (
+        {ingredients.map((food) => (
           <li key={food}>{food}</li>
         ))}
       </ul>

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "turbo": "^2.0.4"
   },
   "lint-staged": {
-    "*.{js,ts,jsx,tsx,css}": [
-      "biome check --write"
-    ]
+    "*.{js,ts,jsx,tsx,css}": ["biome check --write"]
   },
   "volta": {
     "node": "20.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,12 +35,18 @@ importers:
       '@langchain/openai':
         specifier: ^0.1.3
         version: 0.1.3(langchain@0.2.5)
+      axios:
+        specifier: ^1.7.2
+        version: 1.7.2
+      cheerio:
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       hono:
         specifier: ^4.4.5
         version: 4.4.5
       langchain:
         specifier: ^0.2.5
-        version: 0.2.5
+        version: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1795,6 +1801,16 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /axios@1.7.2:
+    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -1814,6 +1830,10 @@ packages:
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
     dev: true
+
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -1875,6 +1895,30 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1981,6 +2025,21 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2035,6 +2094,33 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
@@ -2054,6 +2140,11 @@ packages:
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /esbuild@0.17.19:
     resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
@@ -2192,6 +2283,16 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /foreground-child@3.2.1:
     resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
     engines: {node: '>=14'}
@@ -2320,6 +2421,15 @@ packages:
     engines: {node: '>=16.0.0'}
     dev: false
 
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -2444,7 +2554,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /langchain@0.2.5:
+  /langchain@0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12):
     resolution: {integrity: sha512-H5WL0NanCdQ+tzoeEt7Fyz9YGdR3wbfDvfQrJvxAO95istKo5JraRh24dzyvqxM9439xwRMNaMIpMwsyqtWDtQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -2603,7 +2713,9 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)
       '@langchain/openai': 0.1.3(langchain@0.2.5)
       '@langchain/textsplitters': 0.0.3(langchain@0.2.5)
+      axios: 1.7.2
       binary-extensions: 2.3.0
+      cheerio: 1.0.0-rc.12
       js-tiktoken: 1.0.12
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
@@ -2642,7 +2754,7 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)
       '@types/uuid': 9.0.8
       commander: 10.0.1
-      langchain: 0.2.5
+      langchain: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
@@ -2665,7 +2777,7 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)(openai@4.51.0)
       '@types/uuid': 9.0.8
       commander: 10.0.1
-      langchain: 0.2.5
+      langchain: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
       openai: 4.51.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -2931,6 +3043,12 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /num-sort@2.1.0:
     resolution: {integrity: sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==}
     engines: {node: '>=8'}
@@ -3011,6 +3129,19 @@ packages:
   /package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
     dev: true
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
+    dev: false
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3146,6 +3277,10 @@ packages:
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
     dev: true
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@langchain/openai':
         specifier: ^0.1.3
         version: 0.1.3(langchain@0.2.5)
-      axios:
-        specifier: ^1.7.2
-        version: 1.7.2
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -46,7 +43,7 @@ importers:
         version: 4.4.5
       langchain:
         specifier: ^0.2.5
-        version: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
+        version: 0.2.5(cheerio@1.0.0-rc.12)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1801,16 +1798,6 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /axios@1.7.2:
-    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
-    dependencies:
-      follow-redirects: 1.15.6
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -2283,16 +2270,6 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /follow-redirects@1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /foreground-child@3.2.1:
     resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
     engines: {node: '>=14'}
@@ -2554,7 +2531,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /langchain@0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12):
+  /langchain@0.2.5(cheerio@1.0.0-rc.12):
     resolution: {integrity: sha512-H5WL0NanCdQ+tzoeEt7Fyz9YGdR3wbfDvfQrJvxAO95istKo5JraRh24dzyvqxM9439xwRMNaMIpMwsyqtWDtQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -2713,7 +2690,6 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)
       '@langchain/openai': 0.1.3(langchain@0.2.5)
       '@langchain/textsplitters': 0.0.3(langchain@0.2.5)
-      axios: 1.7.2
       binary-extensions: 2.3.0
       cheerio: 1.0.0-rc.12
       js-tiktoken: 1.0.12
@@ -2754,7 +2730,7 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)
       '@types/uuid': 9.0.8
       commander: 10.0.1
-      langchain: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
+      langchain: 0.2.5(cheerio@1.0.0-rc.12)
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
@@ -2777,7 +2753,7 @@ packages:
       '@langchain/core': 0.2.6(langchain@0.2.5)(openai@4.51.0)
       '@types/uuid': 9.0.8
       commander: 10.0.1
-      langchain: 0.2.5(axios@1.7.2)(cheerio@1.0.0-rc.12)
+      langchain: 0.2.5(cheerio@1.0.0-rc.12)
       openai: 4.51.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -3277,10 +3253,6 @@ packages:
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
     dev: true
-
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}


### PR DESCRIPTION
# Add Recipe Fetching Feature and Update Schema

## 変更内容
1. レシピ取得機能の実装
   - 受け取った食材のリストからリクエストURLを生成
   - APIからレシピ情報を取得し、必要なデータを整形
   - エラーハンドリングの実装（APIリクエスト失敗時の処理）


2. レシピ、フードスキーマの更新
　- foodListをfoodsに改名
　- ingredientListをingredientsに改名



