### PR TITLE
fix(frontend): update OGP path to absolute paths

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,10 +15,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.14.0
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.3.0
       - run: pnpm install
+      - name: Check package versions
+        run: |
+          echo "--- Global TypeScript version ---"
+          pnpm list typescript
+          echo "--- Frontend TypeScript version ---"
+          cd apps/frontend && pnpm list typescript
+          echo "--- Backend TypeScript version ---"
+          cd ../../apps/backend && pnpm list typescript
       - run: pnpm run check
       - run: pnpm run typecheck

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -12,7 +12,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://chefcam.keito.dev" />
-    <meta property="og:image" content="/thumbnail.png" />
+    <meta property="og:image" content="https://chefcam.keito.dev/thumbnail.png" />
     <meta property="og:site_name" content="ChefCamp." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="ChefCamp." />
@@ -20,7 +20,7 @@
       name="twitter:description"
       content="Find recipes from just a photo of the ingredients with AI."
     />
-    <meta name="twitter:image" content="/thumbnail.png" />
+    <meta name="twitter:image" content="https://chefcam.keito.dev/thumbnail.png" />
     <title>ChefCam.</title>
   </head>
   <body class="m-0 h-svh">


### PR DESCRIPTION
This pull request updates the Open Graph and Twitter metadata in the `apps/frontend/index.html` file to use absolute URLs for the `og:image` and `twitter:image` properties.

Metadata updates:

* Updated the `og:image` property to use an absolute URL (`https://chefcam.keito.dev/thumbnail.png`) instead of a relative path (`/thumbnail.png`).
* Updated the `twitter:image` property to use an absolute URL (`https://chefcam.keito.dev/thumbnail.png`) instead of a relative path (`/thumbnail.png`).